### PR TITLE
Bin Labels

### DIFF
--- a/composeml/conftest.py
+++ b/composeml/conftest.py
@@ -1,5 +1,6 @@
 # flake8:noqa
 import pytest
+
 from composeml.tests.test_label_times import labels
 
 

--- a/composeml/conftest.py
+++ b/composeml/conftest.py
@@ -1,0 +1,8 @@
+# flake8:noqa
+import pytest
+from composeml.tests.test_label_times import labels
+
+
+@pytest.fixture(autouse=True)
+def add_labels(doctest_namespace, labels):
+    doctest_namespace['labels'] = labels

--- a/composeml/label_times.py
+++ b/composeml/label_times.py
@@ -136,11 +136,11 @@ class LabelTimes(pd.DataFrame):
         Args:
             bins (int or array) : The criteria to bin by.
 
-                * int : Number of bins either equal-width or quantile-based.
+                * bins (int) : Number of bins either equal-width or quantile-based.
                     If `quantiles` is `False`, defines the number of equal-width bins.
                     The range is extended by .1% on each side to include the minimum and maximum values.
                     If `quantiles` is `True`, defines the number of quantiles (e.g. 10 for deciles, 4 for quartiles, etc.)
-                * array : Bin edges as defined values or quantiles.
+                * bins (array) : Bin edges either user defined or quantile-based.
                     If `quantiles` is `False`, defines the bin edges allowing for non-uniform width. No extension is done.
                     If `quantiles` is `True`, defines the bin edges usings an array of quantiles (e.g. [0, .25, .5, .75, 1.] for quartiles)
 
@@ -150,6 +150,57 @@ class LabelTimes(pd.DataFrame):
 
         Returns:
             LabelTimes : Instance of labels.
+
+        Examples
+        --------
+        .. _equal-widths:
+
+        Using bins of `equal-widths`_:
+
+        >>> labels.bin(2).head()
+                                        my_labeling_function
+        customer_id time                                    
+        1           2014-01-01 00:45:00      (157.5, 283.46]
+                    2014-01-01 00:48:00      (31.288, 157.5]
+        2           2014-01-01 00:01:00      (157.5, 283.46]
+                    2014-01-01 00:04:00      (31.288, 157.5]
+
+        .. _custom-widths:
+
+        Using bins of `custom-widths`_:
+
+        >>> bins = [0, 200, 400]
+        >>> labels.bin(bins).head()
+                                        my_labeling_function
+        customer_id time                                    
+        1           2014-01-01 00:45:00           (200, 400]
+                    2014-01-01 00:48:00             (0, 200]
+        2           2014-01-01 00:01:00           (200, 400]
+                    2014-01-01 00:04:00             (0, 200]
+
+        .. _quantile-based:
+
+        Using `quantile-based`_ bins:
+
+        >>> labels.bin(4, quantiles=True).head() # (i.e. quartiles)
+                                                 my_labeling_function
+        customer_id time                                             
+        1           2014-01-01 00:45:00             (137.44, 241.062]
+                    2014-01-01 00:48:00              (43.848, 137.44]
+        2           2014-01-01 00:01:00             (241.062, 283.46]
+                    2014-01-01 00:04:00  (31.538999999999998, 43.848]
+
+        .. _labels:
+
+        Assigning `labels`_ to bins:
+
+        >>> labels.bin(2, labels=range(2)).head()
+                                        my_labeling_function
+        customer_id time                                    
+        1           2014-01-01 00:45:00                    1
+                    2014-01-01 00:48:00                    0
+        2           2014-01-01 00:01:00                    1
+                    2014-01-01 00:04:00                    0
         """
         data = self.copy()
         name = data.settings['name']

--- a/composeml/label_times.py
+++ b/composeml/label_times.py
@@ -153,9 +153,9 @@ class LabelTimes(pd.DataFrame):
         name = data.settings['name']
 
         if quantiles:
-            data[name] = pd.qcut(data[name], q=bins, labels=labels)
+            data[name] = pd.qcut(data[name].values, q=bins, labels=labels)
 
         else:
-            data[name] = pd.cut(data[name], bins=bins, labels=labels, right=right)
+            data[name] = pd.cut(data[name].values, bins=bins, labels=labels, right=right)
 
         return data

--- a/composeml/label_times.py
+++ b/composeml/label_times.py
@@ -129,7 +129,7 @@ class LabelTimes(pd.DataFrame):
         if not inplace:
             return labels
 
-    def bin(self, bins, labels=None, right=True, quantiles=False):
+    def bin(self, bins, quantiles=False, labels=None, right=True):
         """
         Bin labels into discrete intervals.
 
@@ -144,63 +144,62 @@ class LabelTimes(pd.DataFrame):
                     If `quantiles` is `False`, defines the bin edges allowing for non-uniform width. No extension is done.
                     If `quantiles` is `True`, defines the bin edges usings an array of quantiles (e.g. [0, .25, .5, .75, 1.] for quartiles)
 
+            quantiles (bool) : Determines whether to use a quantile-based discretization function.
             labels (array) : Specifies the labels for the returned bins. Must be the same length as the resulting bins.
             right (bool) : Indicates whether bins includes the rightmost edge or not. Does not apply to quantile-based bins.
-            quantiles (bool) : Determines whether to use a quantile-based discretization function.
 
         Returns:
             LabelTimes : Instance of labels.
 
-        Examples
-        --------
-        .. _equal-widths:
+        Examples:
+            .. _equal-widths:
 
-        Using bins of `equal-widths`_:
+            Using bins of `equal-widths`_:
 
-        >>> labels.bin(2).head()
-                                        my_labeling_function
-        customer_id time                                    
-        1           2014-01-01 00:45:00      (157.5, 283.46]
-                    2014-01-01 00:48:00      (31.288, 157.5]
-        2           2014-01-01 00:01:00      (157.5, 283.46]
-                    2014-01-01 00:04:00      (31.288, 157.5]
+            >>> labels.bin(2).head()
+                                            my_labeling_function
+            customer_id time                                    
+            1           2014-01-01 00:45:00      (157.5, 283.46]
+                        2014-01-01 00:48:00      (31.288, 157.5]
+            2           2014-01-01 00:01:00      (157.5, 283.46]
+                        2014-01-01 00:04:00      (31.288, 157.5]
 
-        .. _custom-widths:
+            .. _custom-widths:
 
-        Using bins of `custom-widths`_:
+            Using bins of `custom-widths`_:
 
-        >>> bins = [0, 200, 400]
-        >>> labels.bin(bins).head()
-                                        my_labeling_function
-        customer_id time                                    
-        1           2014-01-01 00:45:00           (200, 400]
-                    2014-01-01 00:48:00             (0, 200]
-        2           2014-01-01 00:01:00           (200, 400]
-                    2014-01-01 00:04:00             (0, 200]
+            >>> bins = [0, 200, 400]
+            >>> labels.bin(bins).head()
+                                            my_labeling_function
+            customer_id time                                    
+            1           2014-01-01 00:45:00           (200, 400]
+                        2014-01-01 00:48:00             (0, 200]
+            2           2014-01-01 00:01:00           (200, 400]
+                        2014-01-01 00:04:00             (0, 200]
 
-        .. _quantile-based:
+            .. _quantile-based:
 
-        Using `quantile-based`_ bins:
+            Using `quantile-based`_ bins:
 
-        >>> labels.bin(4, quantiles=True).head() # (i.e. quartiles)
-                                                 my_labeling_function
-        customer_id time                                             
-        1           2014-01-01 00:45:00             (137.44, 241.062]
-                    2014-01-01 00:48:00              (43.848, 137.44]
-        2           2014-01-01 00:01:00             (241.062, 283.46]
-                    2014-01-01 00:04:00  (31.538999999999998, 43.848]
+            >>> labels.bin(4, quantiles=True).head() # (i.e. quartiles)
+                                                     my_labeling_function
+            customer_id time                                             
+            1           2014-01-01 00:45:00             (137.44, 241.062]
+                        2014-01-01 00:48:00              (43.848, 137.44]
+            2           2014-01-01 00:01:00             (241.062, 283.46]
+                        2014-01-01 00:04:00  (31.538999999999998, 43.848]
 
-        .. _labels:
+            .. _labels:
 
-        Assigning `labels`_ to bins:
+            Assigning `labels`_ to bins:
 
-        >>> labels.bin(2, labels=range(2)).head()
-                                        my_labeling_function
-        customer_id time                                    
-        1           2014-01-01 00:45:00                    1
-                    2014-01-01 00:48:00                    0
-        2           2014-01-01 00:01:00                    1
-                    2014-01-01 00:04:00                    0
+            >>> labels.bin(3, labels=['low', 'medium', 'high']).head()
+                                            my_labeling_function
+            customer_id time                                    
+            1           2014-01-01 00:45:00                 high
+                        2014-01-01 00:48:00                  low
+            2           2014-01-01 00:01:00                 high
+                        2014-01-01 00:04:00                  low
         """ # noqa
         data = self.copy()
         name = data.settings['name']

--- a/composeml/label_times.py
+++ b/composeml/label_times.py
@@ -129,20 +129,22 @@ class LabelTimes(pd.DataFrame):
         if not inplace:
             return labels
 
-    def bin(self, bins, labels=None, right=True):
+    def bin(self, bins, labels=None, right=True, quantiles=False):
         """
         Bin labels into discrete intervals.
 
         Args:
-            bins (int or list or tuple) : The criteria to bin by.
-                * int : Defines the number of equal-width bins in the range of `x`. The
-                range of `x` is extended by .1% on each side to include the minimum
-                and maximum values of `x`.
+            bins (int or array) : The criteria to bin by.
+                * int : If `quantiles` is `False`, defines the number of equal-width bins.
+                    The range is extended by .1% on each side to include the minimum and maximum values.
+                    If `quantiles` is `True`, defines the number of quantiles (e.g. 10 for deciles, 4 for quartiles, etc.)
 
-                * list : Defines the bin edges manually allowing for non-uniform
-                width. No extension of the range of `x` is done.
+                * array : If `quantiles` is `False`, defines the bin edges allowing for non-uniform width. No extension is done.
+                    If `quantiles` is `True`, defines array of quantiles (e.g. [0, .25, .5, .75, 1.] for quartiles)
 
-                * tuple : Defines the bin edges using quantiles, e.g. (0, .25, .5, .75, 1.) for quartiles.
+            labels (array) : Specifies the labels for the returned bins. Must be the same length as the resulting bins.
+            right (bool) : Indicates whether bins includes the rightmost edge or not.
+            quantiles (bool) : Determines whether to use a quantile-based discretization function.
 
         Returns:
             LabelTimes : Instance of labels.
@@ -150,7 +152,7 @@ class LabelTimes(pd.DataFrame):
         data = self.copy()
         name = data.settings['name']
 
-        if isinstance(bins, tuple):
+        if quantiles:
             data[name] = pd.qcut(data[name], q=bins, labels=labels)
 
         else:

--- a/composeml/label_times.py
+++ b/composeml/label_times.py
@@ -135,10 +135,10 @@ class LabelTimes(pd.DataFrame):
 
         Args:
             bins (int or array) : The criteria to bin by.
+
                 * int : If `quantiles` is `False`, defines the number of equal-width bins.
                     The range is extended by .1% on each side to include the minimum and maximum values.
                     If `quantiles` is `True`, defines the number of quantiles (e.g. 10 for deciles, 4 for quartiles, etc.)
-
                 * array : If `quantiles` is `False`, defines the bin edges allowing for non-uniform width. No extension is done.
                     If `quantiles` is `True`, defines array of quantiles (e.g. [0, .25, .5, .75, 1.] for quartiles)
 

--- a/composeml/label_times.py
+++ b/composeml/label_times.py
@@ -128,3 +128,32 @@ class LabelTimes(pd.DataFrame):
 
         if not inplace:
             return labels
+
+    def bin(self, bins, labels=None, right=True):
+        """
+        Bin labels into discrete intervals.
+
+        Args:
+            bins (int or list or tuple) : The criteria to bin by.
+                * int : Defines the number of equal-width bins in the range of `x`. The
+                range of `x` is extended by .1% on each side to include the minimum
+                and maximum values of `x`.
+
+                * list : Defines the bin edges manually allowing for non-uniform
+                width. No extension of the range of `x` is done.
+
+                * tuple : Defines the bin edges using quantiles, e.g. (0, .25, .5, .75, 1.) for quartiles.
+
+        Returns:
+            LabelTimes : Instance of labels.
+        """
+        data = self.copy()
+        name = data.settings['name']
+
+        if isinstance(bins, tuple):
+            data[name] = pd.qcut(data[name], q=bins, labels=labels)
+
+        else:
+            data[name] = pd.cut(data[name], bins=bins, labels=labels, right=right)
+
+        return data

--- a/composeml/label_times.py
+++ b/composeml/label_times.py
@@ -201,7 +201,7 @@ class LabelTimes(pd.DataFrame):
                     2014-01-01 00:48:00                    0
         2           2014-01-01 00:01:00                    1
                     2014-01-01 00:04:00                    0
-        """
+        """ # noqa
         data = self.copy()
         name = data.settings['name']
 

--- a/composeml/label_times.py
+++ b/composeml/label_times.py
@@ -143,7 +143,7 @@ class LabelTimes(pd.DataFrame):
                     If `quantiles` is `True`, defines array of quantiles (e.g. [0, .25, .5, .75, 1.] for quartiles)
 
             labels (array) : Specifies the labels for the returned bins. Must be the same length as the resulting bins.
-            right (bool) : Indicates whether bins includes the rightmost edge or not.
+            right (bool) : Indicates whether bins includes the rightmost edge or not. Does not apply to quantile-based bins.
             quantiles (bool) : Determines whether to use a quantile-based discretization function.
 
         Returns:

--- a/composeml/label_times.py
+++ b/composeml/label_times.py
@@ -136,11 +136,13 @@ class LabelTimes(pd.DataFrame):
         Args:
             bins (int or array) : The criteria to bin by.
 
-                * int : If `quantiles` is `False`, defines the number of equal-width bins.
+                * int : Number of bins either equal-width or quantile-based.
+                    If `quantiles` is `False`, defines the number of equal-width bins.
                     The range is extended by .1% on each side to include the minimum and maximum values.
                     If `quantiles` is `True`, defines the number of quantiles (e.g. 10 for deciles, 4 for quartiles, etc.)
-                * array : If `quantiles` is `False`, defines the bin edges allowing for non-uniform width. No extension is done.
-                    If `quantiles` is `True`, defines array of quantiles (e.g. [0, .25, .5, .75, 1.] for quartiles)
+                * array : Bin edges as defined values or quantiles.
+                    If `quantiles` is `False`, defines the bin edges allowing for non-uniform width. No extension is done.
+                    If `quantiles` is `True`, defines the bin edges usings an array of quantiles (e.g. [0, .25, .5, .75, 1.] for quartiles)
 
             labels (array) : Specifies the labels for the returned bins. Must be the same length as the resulting bins.
             right (bool) : Indicates whether bins includes the rightmost edge or not. Does not apply to quantile-based bins.

--- a/composeml/tests/test_label_times.py
+++ b/composeml/tests/test_label_times.py
@@ -67,5 +67,19 @@ def test_lead(labels):
     pd.testing.assert_index_equal(given_time, time)
 
 
+def test_quantile_bins(labels):
+    given_labels = labels.bin(2, quantiles=True)
+
+    answer = [
+        pd.Interval(137.44, 283.46, closed='right'),
+        pd.Interval(31.538999999999998, 137.44, closed='right'),
+        pd.Interval(137.44, 283.46, closed='right'),
+        pd.Interval(31.538999999999998, 137.44, closed='right'),
+    ]
+
+    labels['my_labeling_function'] = pd.Categorical(answer, ordered=True)
+    pd.testing.assert_frame_equal(given_labels, labels)
+
+
 def test_describe(labels):
     assert labels.describe() is None

--- a/composeml/tests/test_label_times.py
+++ b/composeml/tests/test_label_times.py
@@ -67,6 +67,20 @@ def test_lead(labels):
     pd.testing.assert_index_equal(given_time, time)
 
 
+def test_bins(labels):
+    given_labels = labels.bin(2)
+
+    answer = [
+        pd.Interval(157.5, 283.46, closed='right'),
+        pd.Interval(31.288, 157.5, closed='right'),
+        pd.Interval(157.5, 283.46, closed='right'),
+        pd.Interval(31.288, 157.5, closed='right'),
+    ]
+
+    labels['my_labeling_function'] = pd.Categorical(answer, ordered=True)
+    pd.testing.assert_frame_equal(given_labels, labels)
+
+
 def test_quantile_bins(labels):
     given_labels = labels.bin(2, quantiles=True)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,5 @@
 [tool:pytest]
+addopts = --doctest-modules
 python_files = composeml/tests/*
 filterwarnings =
     ignore::DeprecationWarning


### PR DESCRIPTION
Adds functionality for binning labels, These are examples of usage.

#### Equal-Width Bins
```
>>> labels.bin(5).head()

                                 my_labeling_function
customer_id time
1           2014-01-01 01:45:30   (674.548, 1764.406]
            2014-01-01 03:29:05  (2848.842, 3933.278]
            2014-01-01 03:39:55  (2848.842, 3933.278]
            2014-01-01 04:14:35  (1764.406, 2848.842]
            2014-01-01 04:17:50  (1764.406, 2848.842]
```
#### Custom Bins
```
>>> bins = [650, 3250, 6500]
>>> labels.bin(bins).head()

                                my_labeling_function
customer_id time
1           2014-01-01 01:45:30          (650, 3250]
            2014-01-01 03:29:05          (650, 3250]
            2014-01-01 03:39:55          (650, 3250]
            2014-01-01 04:14:35          (650, 3250]
            2014-01-01 04:17:50          (650, 3250]
```

#### Quantile-Based Bins
```
>>> labels.bin(4, quantiles=True).head()

                                my_labeling_function
customer_id time
1           2014-01-01 01:45:30    (679.969, 2082.2]
            2014-01-01 03:29:05    (2082.2, 3306.18]
            2014-01-01 03:39:55    (2082.2, 3306.18]
            2014-01-01 04:14:35    (2082.2, 3306.18]
            2014-01-01 04:17:50    (2082.2, 3306.18]
```

#### Labeled Bins
```
>>> labels.bin(5, labels=range(5)).head()

                                my_labeling_function
customer_id time
1           2014-01-01 01:45:30                    0
            2014-01-01 03:29:05                    2
            2014-01-01 03:39:55                    2
            2014-01-01 04:14:35                    1
            2014-01-01 04:17:50                    1
```